### PR TITLE
prefer sendBeacon to XMLHttpRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracker_client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "a flexble client error and action track script",
   "main": "src/index.js",
   "directories": {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -30,12 +30,20 @@ dispatcher.prototype = {
   },
   sendError: function(info) {
     var endPoint = this.endPoint(this.config.token)
-    var xhr = getXHR(endPoint)
-    if (util.isString(info)) {
-      xhr.send(info)
+    if (!util.isString(info)) {
+      info = JSON.stringify(info)
+    }
+    if (navigator.sendBeacon) {
+      /*
+      * https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
+      * This method addresses the needs of analytics and diagnostics code that typically attempts to send data to a web server prior to the unloading of the document.
+      * user agents typically ignore asynchronous XMLHttpRequests made in an unload handler
+      */
+      navigator.sendBeacon(endPoint, info);
     }
     else {
-      xhr.send(JSON.stringify(info))
+      var xhr = getXHR(endPoint)
+      xhr.send(info)
     }
   }
 }


### PR DESCRIPTION
when using `sendBeacon`, the data is transmitted asynchronously to the web server when the User Agent has an opportunity to do so, without delaying the unload or affecting the performance of the next navigation.
and it has no issue with cross domain requests.
